### PR TITLE
Chrome crash workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Docker image containing selenium (`2.48`) and the google chrome driver (`2.20`)
 
 ## Usage
 
-One liner: `docker run -it -p 4444:4444 danielfrg/selenium`
+One liner: `docker run -it -v /dev/shm:/dev/shm -p 4444:4444 danielfrg/selenium`
+
+NOTE: the /dev/shm mount is the recommended workaround to chrome crash issue as per [SeleniumHQ/docker-selenium] (https://github.com/SeleniumHQ/docker-selenium#running-the-images)
 
 Selenium UI is available at:
 [http://DOCKERHOST:4444/wd/hub/static/resource/hub.html](http://DOCKERHOST:4444/wd/hub/static/resource/hub.html)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker image containing selenium (`2.48`) and the google chrome driver (`2.20`)
 
 One liner: `docker run -it -v /dev/shm:/dev/shm -p 4444:4444 danielfrg/selenium`
 
-NOTE: the /dev/shm mount is the recommended workaround to chrome crash issue as per [SeleniumHQ/docker-selenium](https://github.com/SeleniumHQ/docker-selenium#running-the-images)
+NOTE: the /dev/shm mount is the recommended workaround for the chrome crash issue as per [SeleniumHQ/docker-selenium](https://github.com/SeleniumHQ/docker-selenium#running-the-images)
 
 Selenium UI is available at:
 [http://DOCKERHOST:4444/wd/hub/static/resource/hub.html](http://DOCKERHOST:4444/wd/hub/static/resource/hub.html)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Docker image containing selenium (`2.48`) and the google chrome driver (`2.20`)
 
 One liner: `docker run -it -v /dev/shm:/dev/shm -p 4444:4444 danielfrg/selenium`
 
-NOTE: the /dev/shm mount is the recommended workaround to chrome crash issue as per [SeleniumHQ/docker-selenium] (https://github.com/SeleniumHQ/docker-selenium#running-the-images)
+NOTE: the /dev/shm mount is the recommended workaround to chrome crash issue as per [SeleniumHQ/docker-selenium](https://github.com/SeleniumHQ/docker-selenium#running-the-images)
 
 Selenium UI is available at:
 [http://DOCKERHOST:4444/wd/hub/static/resource/hub.html](http://DOCKERHOST:4444/wd/hub/static/resource/hub.html)


### PR DESCRIPTION
Hey Daniel,

Thanks for the great remote Selenium tutorial.

I was having issues with chrome crashing when running some basic Python scripts through the remote connection to your image. I found [this fix from the SeleniumHQ page](https://github.com/SeleniumHQ/docker-selenium#running-the-images). It worked for me using your image, and I thought it'd be worth documenting it.

Best,
Zivvers 